### PR TITLE
Make EasyHandle thread-safe

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.github.darvld"
-version = "0.0.1"
+version = "0.0.2"
 
 repositories {
     mavenLocal()

--- a/src/nativeMain/kotlin/kurl/EasyHandle.kt
+++ b/src/nativeMain/kotlin/kurl/EasyHandle.kt
@@ -4,6 +4,14 @@ package kurl
 
 import kotlinx.cinterop.*
 import libcurl.*
+import kotlin.native.concurrent.AtomicInt
+
+@ExperimentalUnsignedTypes
+/**Creates a new [EasyHandle] and configures it.
+ *
+ * You may use this method as a builder, or store its result and use it later.*/
+public fun easyHandle(setup: EasyHandle.() -> Unit = {}): EasyHandle =
+    EasyHandle(curl_easy_init()).init().apply(setup)
 
 @ExperimentalUnsignedTypes
 /** Representation of libcurl's easy handle objects.
@@ -13,40 +21,41 @@ import libcurl.*
  *
  * If you only need to use the handle once, you can call the [use] method, which will automatically dispose it for you.*/
 public class EasyHandle internal constructor(public val self: COpaquePointer?) {
-
+    /**A [HandleInfo] instance configured with this [EasyHandle]. Use this to retrieve information related to the last
+     * performed call.
+     *
+     * Note that the [HandleInfo] returned by this property is a persistent object that can be re-used as many times
+     * as it is necessary.*/
     public val info: HandleInfo by lazy { HandleInfo(self) }
-    public var disposed: Boolean = false
 
-    /**Initialize this handle with some options specific to our kotlin implementation, like the write callback.*/
+    /**Atomic flag representing the current state of the handle. Don't modify this yourself unless you absolutely know what you are doing.*/
+    @PublishedApi
+    internal var state: AtomicInt = AtomicInt(STATE_NEW)
+
+    /**Initialize this handle with some options like a custom write callback (necessary for the [perform]
+     *  method implementation]).*/
     internal fun init(): EasyHandle = apply {
+        if(!state.compareAndSet(STATE_NEW, STATE_ARMED))
+            return@apply
+
         curl_easy_setopt(self, CURLOPT_WRITEFUNCTION, staticCFunction(::writeMemoryCallback))
         curl_easy_setopt(self, CURLOPT_HEADERFUNCTION, staticCFunction(::writeMemoryCallback))
     }
 
-    public inline fun safeRun(block: EasyHandle.() -> Unit): EasyHandle {
-        require(!disposed) { "Attempt to use an EasyHandle after a call to cleanup()" }
+    /**Run the given [block] on this [EasyHandle], checking whether it has already been disposed,
+     *  and throwing an exception in that case.*/
+    public inline fun safeRun(catch: Boolean = false, block: EasyHandle.() -> Unit): EasyHandle = try {
+        require(state.value != STATE_DISPOSED) { "Attempt to use an EasyHandle after a call to cleanup()" }
 
-        return apply(block)
+        apply(block)
+    } catch (e: Throwable) {
+        if (catch) this else throw e
     }
 
-    /**Controls whether this handle will enforce the verification of SSL certificates.
-     *
-     * By default this is set to true.*/
-    public inline fun verifyCertificates(enabled: Boolean = true): EasyHandle = safeRun {
-        curl_easy_setopt(self, CURLOPT_SSL_VERIFYPEER, if (enabled) 1L else 0L)
-    }
-
-    public inline fun failOnError(enabled: Boolean = true): EasyHandle = safeRun {
-        curl_easy_setopt(self, CURLOPT_FAILONERROR, if (enabled) 1L else 0L)
-    }
-
-    /**Output libcurl debugging information.*/
-    public inline fun verbose(enabled: Boolean = true): EasyHandle = safeRun {
-        curl_easy_setopt(self, CURLOPT_VERBOSE, if (enabled) 1L else 0L)
-    }
-
-    public inline fun referer(value: String): EasyHandle = safeRun {
-        curl_easy_setopt(self, CURLOPT_REFERER, value)
+    /**Runs [op] on this handle and calls [cleanup] after it is done. Useful for one-time disposable handles.*/
+    public inline fun use(op: EasyHandle.() -> Unit) {
+        this.op()
+        cleanup()
     }
 
     /**Set the target [url].
@@ -80,6 +89,21 @@ public class EasyHandle internal constructor(public val self: COpaquePointer?) {
         return@memScoped Response(info.responseCode.toInt(), header, body)
     }
 
+    /**Set the next operation to an HTTP GET request.*/
+    public inline fun get(): EasyHandle = safeRun {
+        curl_easy_setopt(self, CURLOPT_HTTPGET, 1L)
+    }
+
+    /**Executes an HTTP GET request to the given [targetUrl], or the current url if none is specified,
+     *  prior to calling [perform] and returning its result, the [setup] function is applied to the handle.*/
+    public inline fun get(targetUrl: String? = null, setup: EasyHandle.() -> Unit = {}): Response? {
+        get()
+        targetUrl?.let { this.url(it) }
+        setup(this)
+
+        return perform()
+    }
+
     /**Set the next operation to HTTP POST.*/
     public inline fun post(): EasyHandle = safeRun {
         curl_easy_setopt(self, CURLOPT_HTTPGET, 1L)
@@ -95,15 +119,38 @@ public class EasyHandle internal constructor(public val self: COpaquePointer?) {
         post()
         targetUrl?.let { url(it) }
         fields?.let { postFields(it) }
-        setup()
+        setup(this)
 
         return perform()
     }
 
+    /**Setup the [fields] that will be used in subsequent [post] calls.*/
     public inline fun postFields(fields: String) {
         val cString = fields.cstr
         curl_easy_setopt(self, CURLOPT_POSTFIELDS, cString)
         curl_easy_setopt(self, CURLOPT_POSTFIELDSIZE, cString.size)
+    }
+
+    /**Output libcurl debugging information to console.*/
+    public inline fun verbose(enabled: Boolean = true): EasyHandle = safeRun {
+        curl_easy_setopt(self, CURLOPT_VERBOSE, if (enabled) 1L else 0L)
+    }
+
+    /**Controls whether this handle will enforce the verification of SSL certificates.
+     *
+     * By default this is set to true.*/
+    public inline fun verifyCertificates(enabled: Boolean = true): EasyHandle = safeRun {
+        curl_easy_setopt(self, CURLOPT_SSL_VERIFYPEER, if (enabled) 1L else 0L)
+    }
+
+    /**Make cURL return an actual error if a response's code is 400 or higher, [CurlException] will be thrown in that case.*/
+    public inline fun failOnError(enabled: Boolean = true): EasyHandle = safeRun {
+        curl_easy_setopt(self, CURLOPT_FAILONERROR, if (enabled) 1L else 0L)
+    }
+
+    /**Set the referer URL to [value].*/
+    public inline fun referer(value: String): EasyHandle = safeRun {
+        curl_easy_setopt(self, CURLOPT_REFERER, value)
     }
 
     /**Whether to include response headers in the body of [perform] responses.
@@ -118,21 +165,6 @@ public class EasyHandle internal constructor(public val self: COpaquePointer?) {
         curl_easy_setopt(self, CURLOPT_USERAGENT, agent)
     }
 
-    /**Set the next operation to an HTTP GET request.*/
-    public inline fun get(): EasyHandle = safeRun {
-        curl_easy_setopt(self, CURLOPT_HTTPGET, 1L)
-    }
-
-    /**Executes an HTTP GET request to the given [targetUrl], or the current url if none is specified,
-     *  prior to calling [perform] and returning its result, the [setup] function is applied to the handle.*/
-    public inline fun get(targetUrl: String? = null, setup: EasyHandle.() -> Unit = {}): Response? {
-        get()
-        targetUrl?.let { this.url(it) }
-        setup()
-
-        return perform()
-    }
-
     /**Set the [value] of the given [cookie].*/
     public inline fun setCookie(cookie: String, value: String): EasyHandle = safeRun {
         curl_easy_setopt(self, CURLOPT_COOKIE, "$cookie=$value;")
@@ -141,22 +173,15 @@ public class EasyHandle internal constructor(public val self: COpaquePointer?) {
     /**Dispose this handle, it must not be used after this.*/
     public inline fun cleanup() {
         curl_easy_cleanup(self)
-        disposed = true
-    }
-
-    /**Runs [op] on this handle and calls [cleanup] after it is done. Useful for one-time disposable handles.*/
-    public inline fun use(op: EasyHandle.() -> Unit) {
-        op()
-        cleanup()
+        state.value = STATE_DISPOSED
     }
 
     /**Encode the given [string] to a URL-compliant [String].*/
     public inline fun urlEncode(string: String): String = curl_easy_escape(self, string, string.length)!!.toKString()
-}
 
-@ExperimentalUnsignedTypes
-/**Creates a new [EasyHandle] and configures it.
- *
- * You may use this method as a builder, or store its result and use it later.*/
-public fun easyHandle(setup: EasyHandle.() -> Unit = {}): EasyHandle =
-    EasyHandle(curl_easy_init()).init().apply(setup)
+    public companion object {
+        public const val STATE_NEW: Int = 0
+        public const val STATE_ARMED: Int = 1
+        public const val STATE_DISPOSED: Int = 2
+    }
+}

--- a/src/nativeMain/kotlin/kurl/Info.kt
+++ b/src/nativeMain/kotlin/kurl/Info.kt
@@ -3,151 +3,179 @@
 package kurl
 
 import kotlinx.cinterop.*
-import kotlinx.cinterop.nativeHeap.alloc
 import libcurl.*
 
-public class HandleInfo (public val handle: COpaquePointer?) {
+/**Helper class used to retrieve information related to the latest http call performed by [handle].
+ *
+ * Do not construct instances of this class directly unless you have created the Curl handle by yourself,
+ * use [EasyHandle.info] instead.
+ *
+ * [HandleInfo] objects are meant to be reused, none of its properties have backing fields, so they will always
+ * return an updated value as the result of a call to the underlying C API. For repeated access of one property
+ * you should cache the result in a local variable to avoid unnecessary method calls (unless you expect to obtain
+ * different results).*/
+public class HandleInfo(public val handle: COpaquePointer?) {
     public inline val effectiveUrl: String
         get() = memScoped {
             val data = allocPointerTo<ByteVar>()
-            curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_URL , data.ptr)
+            curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_URL, data.ptr)
 
-            return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_EFFECTIVE_URL")
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_EFFECTIVE_URL")
         }
 
-    public inline val responseCode: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, data.ptr)
+    public inline val responseCode: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_RESPONSE_CODE, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val totalTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_TOTAL_TIME, data.ptr)
+    public inline val totalTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_TOTAL_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val nameLookupTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_NAMELOOKUP_TIME, data.ptr)
+    public inline val nameLookupTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_NAMELOOKUP_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val connectTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_CONNECT_TIME, data.ptr)
+    public inline val connectTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_CONNECT_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val preTransferTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_PRETRANSFER_TIME, data.ptr)
+    public inline val preTransferTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_PRETRANSFER_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val sizeUpload: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_SIZE_UPLOAD, data.ptr)
+    public inline val sizeUpload: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_SIZE_UPLOAD, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val sizeDownload: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_SIZE_DOWNLOAD, data.ptr)
+    public inline val sizeDownload: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_SIZE_DOWNLOAD, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val speedDownload: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_SPEED_DOWNLOAD, data.ptr)
+    public inline val speedDownload: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_SPEED_DOWNLOAD, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val speedUpload: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_SPEED_UPLOAD, data.ptr)
+    public inline val speedUpload: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_SPEED_UPLOAD, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val headerSize: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_HEADER_SIZE, data.ptr)
+    public inline val headerSize: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_HEADER_SIZE, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val requestSize: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_REQUEST_SIZE, data.ptr)
+    public inline val requestSize: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_REQUEST_SIZE, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val sslVerifyResult: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_SSL_VERIFYRESULT, data.ptr)
+    public inline val sslVerifyResult: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_SSL_VERIFYRESULT, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val fileTime: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_FILETIME, data.ptr)
+    public inline val fileTime: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_FILETIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val contentLengthDownload: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, data.ptr)
+    public inline val contentLengthDownload: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_CONTENT_LENGTH_DOWNLOAD, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val contentLengthUpload: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_CONTENT_LENGTH_UPLOAD, data.ptr)
+    public inline val contentLengthUpload: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_CONTENT_LENGTH_UPLOAD, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val startTransferTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_STARTTRANSFER_TIME, data.ptr)
+    public inline val startTransferTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_STARTTRANSFER_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
     public inline val contentType: String
-    get() = memScoped {
-        val data = allocPointerTo<ByteVar>()
-        curl_easy_getinfo(handle, CURLINFO_CONTENT_TYPE, data.ptr)
+        get() = memScoped {
+            val data = allocPointerTo<ByteVar>()
+            curl_easy_getinfo(handle, CURLINFO_CONTENT_TYPE, data.ptr)
 
-        return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_CONTENT_TYPE")
-    }
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_CONTENT_TYPE")
+        }
 
-    public inline val redirectTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_REDIRECT_TIME, data.ptr)
+    public inline val redirectTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_REDIRECT_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val redirectCount: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_REDIRECT_COUNT, data.ptr)
+    public inline val redirectCount: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_REDIRECT_COUNT, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
     public inline val private: String
         get() = memScoped {
@@ -157,54 +185,61 @@ public class HandleInfo (public val handle: COpaquePointer?) {
             return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_PRIVATE")
         }
 
-    public inline val httpConnectCode: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_HTTP_CONNECTCODE, data.ptr)
+    public inline val httpConnectCode: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_HTTP_CONNECTCODE, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val httpAuthAvail: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_HTTPAUTH_AVAIL, data.ptr)
+    public inline val httpAuthAvail: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_HTTPAUTH_AVAIL, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val proxyAuthAvail: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_PROXYAUTH_AVAIL, data.ptr)
+    public inline val proxyAuthAvail: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_PROXYAUTH_AVAIL, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val osErrno: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_OS_ERRNO, data.ptr)
+    public inline val osErrno: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_OS_ERRNO, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val numConnects: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_NUM_CONNECTS, data.ptr)
+    public inline val numConnects: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_NUM_CONNECTS, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val lastSocket: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_LASTSOCKET, data.ptr)
+    public inline val lastSocket: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_LASTSOCKET, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
     public inline val ftpEntryPath: String
         get() = memScoped {
             val data = allocPointerTo<ByteVar>()
             curl_easy_getinfo(handle, CURLINFO_FTP_ENTRY_PATH, data.ptr)
 
-            return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_FTP_ENTRY_PATH")
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_FTP_ENTRY_PATH")
         }
 
     public inline val redirectUrl: String
@@ -212,7 +247,8 @@ public class HandleInfo (public val handle: COpaquePointer?) {
             val data = allocPointerTo<ByteVar>()
             curl_easy_getinfo(handle, CURLINFO_REDIRECT_URL, data.ptr)
 
-            return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_REDIRECT_URL")
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_REDIRECT_URL")
         }
 
     public inline val primaryIp: String
@@ -220,65 +256,74 @@ public class HandleInfo (public val handle: COpaquePointer?) {
             val data = allocPointerTo<ByteVar>()
             curl_easy_getinfo(handle, CURLINFO_PRIMARY_IP, data.ptr)
 
-            return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_PRIMARY_IP")
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_PRIMARY_IP")
         }
 
-    public inline val appConnectTime: Double get() = memScoped {
-        val data = alloc<DoubleVar>()
-        curl_easy_getinfo(handle, CURLINFO_APPCONNECT_TIME, data.ptr)
+    public inline val appConnectTime: Double
+        get() = memScoped {
+            val data = alloc<DoubleVar>()
+            curl_easy_getinfo(handle, CURLINFO_APPCONNECT_TIME, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val certInfo: COpaquePointer? get() = memScoped {
-        val data = alloc<COpaquePointerVar>()
-        curl_easy_getinfo(handle, CURLINFO_CERTINFO, data.ptr)
+    public inline val certInfo: COpaquePointer?
+        get() = memScoped {
+            val data = alloc<COpaquePointerVar>()
+            curl_easy_getinfo(handle, CURLINFO_CERTINFO, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val conditionUnmet: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_CONDITION_UNMET, data.ptr)
+    public inline val conditionUnmet: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_CONDITION_UNMET, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
     public inline val rtspSessionId: String
         get() = memScoped {
             val data = allocPointerTo<ByteVar>()
             curl_easy_getinfo(handle, CURLINFO_RTSP_SESSION_ID, data.ptr)
 
-            return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_RTSP_SESSION_ID")
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_RTSP_SESSION_ID")
         }
 
-    public inline val rtspClientCseq: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_RTSP_CLIENT_CSEQ, data.ptr)
+    public inline val rtspClientCseq: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_RTSP_CLIENT_CSEQ, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val rtspServerCseq: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_RTSP_SERVER_CSEQ, data.ptr)
+    public inline val rtspServerCseq: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_RTSP_SERVER_CSEQ, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val rtspCseqRecv: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_RTSP_CSEQ_RECV, data.ptr)
+    public inline val rtspCseqRecv: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_RTSP_CSEQ_RECV, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val primaryPort: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_PRIMARY_PORT, data.ptr)
+    public inline val primaryPort: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_PRIMARY_PORT, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
     public inline val localIp: String
         get() = memScoped {
@@ -288,47 +333,53 @@ public class HandleInfo (public val handle: COpaquePointer?) {
             return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_LOCAL_IP")
         }
 
-    public inline val localPort: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_LOCAL_PORT, data.ptr)
+    public inline val localPort: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_LOCAL_PORT, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val tlsSession: COpaquePointer? get() = memScoped {
-        val data = alloc<COpaquePointerVar>()
-        curl_easy_getinfo(handle, CURLINFO_TLS_SESSION, data.ptr)
+    public inline val tlsSession: COpaquePointer?
+        get() = memScoped {
+            val data = alloc<COpaquePointerVar>()
+            curl_easy_getinfo(handle, CURLINFO_TLS_SESSION, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val tlsSSLPtr: COpaquePointer? get() = memScoped {
-        val data = alloc<COpaquePointerVar>()
-        curl_easy_getinfo(handle, CURLINFO_TLS_SSL_PTR, data.ptr)
+    public inline val tlsSSLPtr: COpaquePointer?
+        get() = memScoped {
+            val data = alloc<COpaquePointerVar>()
+            curl_easy_getinfo(handle, CURLINFO_TLS_SSL_PTR, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val httpVersion: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_HTTP_VERSION, data.ptr)
+    public inline val httpVersion: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_HTTP_VERSION, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val proxySslVerifyResult: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_PROXY_SSL_VERIFYRESULT, data.ptr)
+    public inline val proxySslVerifyResult: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_PROXY_SSL_VERIFYRESULT, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
-    public inline val protocol: Long get() = memScoped {
-        val data = alloc<LongVar>()
-        curl_easy_getinfo(handle, CURLINFO_PROTOCOL, data.ptr)
+    public inline val protocol: Long
+        get() = memScoped {
+            val data = alloc<LongVar>()
+            curl_easy_getinfo(handle, CURLINFO_PROTOCOL, data.ptr)
 
-        return data.value
-    }
+            return data.value
+        }
 
     public inline val scheme: String
         get() = memScoped {
@@ -343,7 +394,8 @@ public class HandleInfo (public val handle: COpaquePointer?) {
             val data = allocPointerTo<ByteVar>()
             curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_METHOD, data.ptr)
 
-            return data.value?.toKString() ?: throw CurlException("Error retrieving requested info: CURLINFO_EFFECTIVE_METHOD")
+            return data.value?.toKString()
+                ?: throw CurlException("Error retrieving requested info: CURLINFO_EFFECTIVE_METHOD")
         }
 
 }


### PR DESCRIPTION
An `AtomicInt` flag is used to monitor the state of the handle so it can be used from any thread, the state flag prevents certain operations from running twice, such as `cleanup()` and `init()`